### PR TITLE
Add get_hostname() method to retrieve device hostname

### DIFF
--- a/test/json/test_json_client_integration.py
+++ b/test/json/test_json_client_integration.py
@@ -657,3 +657,32 @@ async def test_serial_number_consistent_across_calls(real_client):
 
     # Serial number should be the same every time
     assert serial1 == serial2
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_get_hostname(real_client):
+    """Test fetching device hostname."""
+    hostname = await real_client.get_hostname()
+
+    # Should return a non-empty string
+    assert isinstance(hostname, str)
+    assert len(hostname) > 0
+
+    # Per API spec: hostname consists of ASCII letters, digits, and dashes only
+    # Allow alphanumeric characters and dashes
+    assert all(c.isalnum() or c == "-" for c in hostname), (
+        f"Hostname '{hostname}' contains invalid characters. "
+        f"Expected only ASCII letters, digits, and dashes."
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_hostname_consistent_across_calls(real_client):
+    """Test that hostname is consistent across multiple calls."""
+    hostname1 = await real_client.get_hostname()
+    hostname2 = await real_client.get_hostname()
+
+    # Hostname should be the same every time
+    assert hostname1 == hostname2


### PR DESCRIPTION
## Summary

Adds a new `get_hostname()` method to `EgaugeJsonClient` that retrieves the configured hostname from an eGauge device via the `/api/config/net/hostname` JSON API endpoint.

## Implementation Details

- **Endpoint**: `/api/config/net/hostname` (GET)
- **Authentication**: JWT Bearer token (automatic refresh handling)
- **Error Handling**: Distinguishes between authentication failures and permission denials
- **Return Value**: Hostname string (ASCII letters, digits, and dashes only)
- **Pattern**: Follows the same implementation pattern as `get_device_serial_number()`

## Testing

### Unit Tests (6 new tests)
- ✅ Success case with valid hostname
- ✅ Hostname containing dashes
- ✅ JWT Bearer token authentication verification
- ✅ Missing result field error handling
- ✅ Permission denied error (authenticated user without permission)
- ✅ Authentication failure error (invalid credentials)

### Integration Tests (2 new tests)
- ✅ Fetch hostname from real device and validate format
- ✅ Verify hostname consistency across multiple calls

### Code Quality
- ✅ All 47 unit tests passing
- ✅ Formatted with ruff
- ✅ Linted with ruff (no issues)
- ✅ Type-checked with pyright (0 errors)

## Test Plan

- [x] Unit tests pass locally
- [x] Code quality checks pass (ruff format, ruff check, pyright)
- [x] Integration tests pass against real eGauge device (requires environment setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)